### PR TITLE
Allow other `onPreResponse` handlers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ exports.register = function(server, options, next) {
    * Check to see if the `data.code` property is defined on the response error object.
    * Make it a part of the output payload object if so.
    */
-  
+
   server.ext('onPreResponse', function(request, reply) {
     var response = request.response;
 
@@ -35,7 +35,7 @@ exports.register = function(server, options, next) {
       error.output.payload.code = error.data.code;
     }
 
-    return reply(error);
+    return reply.continue(error);
   });
 
   next();

--- a/test/hapi-response-errors_test.js
+++ b/test/hapi-response-errors_test.js
@@ -41,7 +41,7 @@ describe('hapi-response-errors', function() {
         if (err) {
           throw err;
         }
-        
+
         done();
       });
 
@@ -64,5 +64,39 @@ describe('hapi-response-errors', function() {
       done();
     });
   });
-  
+
+  describe('multiple onPreResponse handlers', function () {
+    var calls = 0;
+
+    // add a second onPreResponse handler
+    before(function (done) {
+      var testPlugin = {
+        register: function (server, options, next) {
+          server.ext('onPreResponse', function(request, reply) {
+            calls += 1;
+            return reply.continue();
+          });
+
+          return next();
+        }
+      };
+      testPlugin.register.attributes = { name: 'test' };
+
+      server.register(testPlugin, function (err) {
+        if (err) {
+          throw err;
+        }
+
+        done();
+      })
+    });
+
+    it('should call the second plugin', function (done) {
+      server.inject('/', function(res) {
+        calls.should.equal(1);
+
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Hey,

thanks for this great hapi plugin! Recently I wanted to integrate hapi-statsd and realised that just calling `reply(err)` prevents other handlers from working correctly. So it's better to call `reply.continue(err)` instead of plain reply to allow other handlers.
